### PR TITLE
Fix Circle CI testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,6 @@ parameters:
     default: "A Satis build was triggered for an unknown reason."
 
 jobs:
-
   build:
     docker:
       - image: composer/satis
@@ -24,21 +23,11 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Build all satis repos.
+          name: Build or prepare satis /app
           command: |
-            # Read-only access to github. @todo replace with GovCMS generated one at https://circleci.com/gh/govCMS/satis/edit#env-vars
-            # https://blog.simplytestable.com/creating-and-using-a-github-oauth-token-with-travis-and-composer/
-            mkdir /composer && echo "{\"github-oauth\":{\"github.com\":\""${GITHUB_READ_ONLY_OAUTH}"\"}}" > /composer/auth.json
-            # When an upstream package changes, no assumptions about which satis config references it; build all.
-            "${SATIS}" build satis-config/govcms-stable.json "${SATIS_BUILD}"
-            ./branding/branding.sh "${SATIS_BUILD}"
-            "${SATIS}" build satis-config/govcms-develop.json "${SATIS_BUILD}"/develop
-            ./branding/branding.sh "${SATIS_BUILD}"/develop
-            "${SATIS}" build satis-config/govcms-master.json "${SATIS_BUILD}"/master
-            ./branding/branding.sh "${SATIS_BUILD}"/master
-            "${SATIS}" build satis-config/govcms-whitelist.json "${SATIS_BUILD}"/whitelist
-            ./branding/branding.sh "${SATIS_BUILD}"/whitelist
-            cp ./branding/logo.svg ./branding/favicon.png "${SATIS_BUILD}"
+            # If satis build was automated, it would happen here. Currently just copy the committed /app to the build directory.
+            mkdir -p "${SATIS_BUILD}"
+            cp -R app/* "${SATIS_BUILD}"
       - persist_to_workspace:
           root: /tmp/satis-build
           paths:
@@ -57,19 +46,43 @@ jobs:
       - run:
           name: Test that GovCMS can be built
           command: |
+            # Get package versions required for testing stable release.
+            VERSION_GOVCMS=$(cat ./satis-config/govcms-stable.json | jq -r '.require | .["govcms/govcms"]')
+            VERSION_TOOLING=$(cat ./satis-config/govcms-stable.json | jq -r '.require | .["govcms/scaffold-tooling"]')
+            VERSION_DEV=$(cat ./satis-config/govcms-stable.json | jq -r '.require | .["govcms/require-dev"]')
+
+            echo "--> Starting satis web server on http://localhost:4141"
             php -S localhost:4141 -t "${SATIS_BUILD}" > /tmp/phpd.log 2>&1 &
-            composer create-project govcms/govcms8-scaffold-paas "${GOVCMS_SCAFFOLD}"
+            echo "--> Cloning govcms8-scaffold-paas into ${GOVCMS_SCAFFOLD}"
+            composer create-project --no-install --quiet govcms/govcms8-scaffold-paas "${GOVCMS_SCAFFOLD}"
             cd "${GOVCMS_SCAFFOLD}"
+            composer config secure-http false
+
             for branch in {"","develop","master"}; do
+              echo
+              echo "--> --------------------------------------------------------"
               echo "--> Test build GovCMS against http://localhost:4141/${branch}"
-              rm -R vendor && rm composer.lock
-              composer config secure-http false
+              echo
+
+              rm -fR vendor && rm -f composer.lock
               composer config repositories.govcms composer http://localhost:4141/"${branch}"
               if [ "${branch}" = "master" ] || [ "${branch}" = "develop" ] ; then
-                composer require govcms/govcms:1.x govcms/require-dev:dev-"${branch}" govcms/scaffold-tooling:dev-"${branch}"
+                composer require --no-update \
+                    govcms/govcms:1.x \
+                    govcms/scaffold-tooling:dev-"${branch}" \
+                    govcms/require-dev:dev-"${branch}" \
+                    symfony/event-dispatcher:"v4.3.11 as v3.4.35" # @todo: remove once govcms/govcms no longer requires "symfony/event-dispatcher:v4.3.11 as v3.4.35" which only works at the root composer.json level.
+              else
+                echo -e "--> Expected stable versions, based on the satis config: \n     - govcms/govcms:${VERSION_GOVCMS} \n     - govcms/scaffold-tooling:${VERSION_TOOLING} \n     - govcms/require-dev:${VERSION_DEV}"
+                composer require --no-update \
+                    govcms/govcms:"${VERSION_GOVCMS}" \
+                    govcms/scaffold-tooling:"${VERSION_TOOLING}" \
+                    govcms/require-dev:"${VERSION_DEV}" \
+                    symfony/event-dispatcher:"v4.3.11 as v3.4.35" # @todo: remove once govcms/govcms no longer requires "symfony/event-dispatcher:v4.3.11 as v3.4.35" which only works at the root composer.json level.
               fi
-              composer -n update
-              composer validate
+              cat composer.json | jq .require
+              composer -n --quiet --no-suggest --no-scripts update
+              composer info | grep ^govcms
             done
 
   deploy:
@@ -84,6 +97,9 @@ jobs:
       - run:
           name: Update github develop branch.
           command: |
+            # If builds were automated, this would push the new satis back to git.
+            exit 1
+
             # Currently just testing a push to a test branch.
             git checkout -b test-"${CIRCLE_SHA1}"
             rm -Rf app
@@ -97,6 +113,7 @@ jobs:
             git commit -m"[skip ci] test-commit"
             git push origin test-"${CIRCLE_SHA1}"
 
+
 workflows:
   version: 2.1
   update:
@@ -105,18 +122,10 @@ workflows:
           filters:
             tags:
               ignore: /.*/
-            branches:
-              only:
-                - upstream_changes
-                - develop
       - test:
           filters:
             tags:
               ignore: /.*/
-            branches:
-              only:
-                - upstream_changes
-                - develop
           requires:
             - build
       - deploy:


### PR DESCRIPTION
CircleCI was configured to detect changes in other repositories and rebuild satis. However automated building is looking unfeasible because the process of building satis general requires manual intervention.
 
This CI fixes the test that GovCMS can be built from Satis. It leaves in place the general structure from before, because it was tricky to implement (you need to build satis with one CI image and then test with another). 

<img width="704" alt="Screen Shot 2020-05-06 at 13 13 58" src="https://user-images.githubusercontent.com/188856/81135423-77277980-8f9b-11ea-8811-fb4fecbea68b.png">
