### PR TITLE
Disable deploy job.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,8 +133,7 @@ workflows:
             tags:
               ignore: /.*/
             branches:
-              only:
-                - upstream_changes
-                - develop
+              # Disabled while not automated.
+              ignore: /.*/
           requires:
             - test


### PR DESCRIPTION
The deploy job was enabled for the "develop" branch so tests started failing once it was merged. I've disabled it.